### PR TITLE
Add toml module as explicit requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     py_modules=["black_nbconvert"],
     python_requires=">=3.6",
     zip_safe=False,
-    install_requires=["black", "nbconvert"],
+    install_requires=["black", "nbconvert", "toml"],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Console",


### PR DESCRIPTION
black recently dropped this requirement
(https://github.com/psf/black/pull/2301), so this results in an error if
this is run with a newer version of black.